### PR TITLE
Updated Pro7 protocol

### DIFF
--- a/Pro7.md
+++ b/Pro7.md
@@ -23,9 +23,9 @@ ws://[host]:[port]/remote
 COMMAND TO SEND:
 
 ```javascript
-{"action":"authenticate","protocol":"600","password":"control"}
+{"action":"authenticate","protocol":"700","password":"control"}
 ```
-* protocol is used to perform a version check. ProPresenter 6 seems to check for a value here of at least 600 - otherwise it denies authentication and returns "Protocol out of date. Update application"
+* protocol is used to perform a version check. ProPresenter 7 seems to check for a value here of at least 700 - otherwise it denies authentication and returns "Protocol out of date. Update application"
 
 EXPECTED RESPONSE:
 


### PR DESCRIPTION
This PR simply changes the `protocol` value sent in the `authenticate` message. Naturally, Pro7 made this value `700` rather than `600`.